### PR TITLE
Upgrade CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
     - php: nightly
 
 before_script:
-  - composer self-update
-
   # We use the same repo straight from github because it required lesser amount of hacks
   # Here we force the same current git commit id for composer
   - sed -i -e "s|%%TRAVIS_COMMIT%%|$TRAVIS_COMMIT|g" tests/move/composer.json
@@ -31,10 +29,10 @@ script:
   - php -d error_reporting=32767 -l src/Dropin.php
 
   # Sanity composer check
-  - composer validate composer.json
+  - composer validate --strict
 
   # Install phpunit etc
-  - composer install
+  - composer install --prefer-dist
 
   # Run the real tests finally
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
         "composer-plugin-api": "^1.0 | ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,15 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "php": ">=5.3.2"
         "composer-plugin-api": "^1.0 | ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*-dev"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {
-            "Koodimonni\\Composer\\": "src"
+            "Koodimonni\\Composer\\": "src/"
         }
     },
     "extra": {


### PR DESCRIPTION
- Travis images already include an up-to-date Composer tool
- Properly validating Composer configuration
- Use ZIP-s instead of waiting for git (`--prefer-dist`)
