### PR TITLE
Run CI on modern PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ sudo: false
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
+  - '7.4'
+  - '7.3'
+  - '7.2'
   - '7.1'
-  - hhvm
+  - '7.0'
+  - '5.6'
   - nightly
 
 matrix:


### PR DESCRIPTION
- HHVM is a thing of the past
- Start testing on latest PHP version