### PR TITLE
Update ignore list to consistently include .txt as file type

### DIFF
--- a/src/Dropin.php
+++ b/src/Dropin.php
@@ -37,12 +37,15 @@ class Dropin implements PluginInterface, EventSubscriberInterface {
     ".gitignore",
     "composer.json",
     "composer.lock",
+    "readme",
     "readme.md",
+    "readme.txt",
     "changelog",
     "changelog.md",
-    "readme.txt",
+    "changelog.txt",
     "license",
     "license.md",
+    "license.txt",
     "phpunit.xml",
     ".travis.yml"
   );


### PR DESCRIPTION
This PR makes the list for readme, changelog, and license consistent by including .md, .txt and no extension for each file.